### PR TITLE
Fake dims, rank order swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ In addition, the rank order needs to be swapped sometimes to achieve the best co
 For example, if a 2D slice of dimensions `(64, 128)` has the `dim=128` rank being the fastest
 varying rank, then this slice needs a "rank order swap" to achieve the best compression.
 In general, given dimensions of `(NX, NY, NZ)`, we want the `X` rank to be varying the fastest,
-and the `Z` rank to be varying the slowest.
+and the `Z` rank to be varying the slowest, before the data is passed to the compressor.
+"Rank order swap" helps to achieve it.
 
 The HDF5 libraries takes in these compression parameters as one or more 32-bit `unsigned int` values,
 which are named `cd_values[]` in most HDF5 routines.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ H5Pset_filter(prop, 32028, H5Z_FLAG_MANDATORY, 1, &cd_values);            /* Spe
 See a complete example [here](https://github.com/NCAR/H5Z-SPERR/blob/main/utilities/example-3d.c).
 
 ### Find `cd_values[]` Using the CLI Tool `generate_cd_values`
-After building `H5Z-SPERR`, a command line tool named `generate_cd_values` becomes available to encode 
-1) SPERR compression mode, 2) quality, and 3) if to perform rank order swap
+After building `H5Z-SPERR`, a command line tool named `generate_cd_values` becomes available to encode 1) SPERR 
+compression mode, 2) quality, and 3) if to perform rank order swap
 into a single `unsigned int`. The produced value can then be used in other command line tools such as `h5repack`.
 In the following example, `generate_cd_values` reports that `268651725u` encodes fixed-rate compression with 
 a bitrate of 3.3 bit-per-value, without doing rank order swap.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ what compression quality to use. Supported compression modes and qualities are s
 | 3             | Fixed point-wise error (PWE)            | 0.0 < quality |
 
 In addition, the rank order needs to be swapped sometimes to achieve the best compression.
-For example, if a 2D slice of dimensions `64 x 128` has the dim=128 rank being the fastest
+For example, if a 2D slice of dimensions `(64, 128)` has the `dim=128` rank being the fastest
 varying rank, then this slice needs a "rank order swap" to achieve the best compression.
-In general, given dimensions of `NX x NY x NZ`, we want the `X` rank to be varying the fastest,
+In general, given dimensions of `(NX, NY, NZ)`, we want the `X` rank to be varying the fastest,
 and the `Z` rank to be varying the slowest.
 
 The HDF5 libraries takes in these compression parameters as one or more 32-bit `unsigned int` values,

--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ H5Pset_filter(prop, 32028, H5Z_FLAG_MANDATORY, 1, &cd_values);            /* Spe
 See a complete example [here](https://github.com/NCAR/H5Z-SPERR/blob/main/utilities/example-3d.c).
 
 ### Find `cd_values[]` Using the CLI Tool `generate_cd_values`
-After building `H5Z-SPERR`, a command line tool named `generate_cd_values` becomes available to encode SPERR compression mode
-and quality into a single `unsigned int`. The produced value can then be used in other command line tools such as `h5repack`.
-In the following example, `generate_cd_values` reports that `268651725u` encodes fixed-rate compression with a bitrate of 3.3 bit-per-value.
+After building `H5Z-SPERR`, a command line tool named `generate_cd_values` becomes available to encode 
+1) SPERR compression mode, 2) quality, and 3) if to perform rank order swap
+into a single `unsigned int`. The produced value can then be used in other command line tools such as `h5repack`.
+In the following example, `generate_cd_values` reports that `268651725u` encodes fixed-rate compression with 
+a bitrate of 3.3 bit-per-value, without doing rank order swap.
 ```Bash
 $ ./bin/generate_cd_values 1 3.3
 For fixed-rate compression with a bitrate of 3, without swapping rank orders,

--- a/example/simple_xy_nc4_wr.c
+++ b/example/simple_xy_nc4_wr.c
@@ -79,10 +79,11 @@ main()
     /*
      * Encode SPERR compression parameters:
      * 1 == fixed bitrate mode 
-     * 3.14 == target bitrate
+     * 6.4 == target bitrate
+     * 0 == no rank swaps
      * 32028 == registered ID for the SPERR filter.
      */
-    unsigned int cd_values = H5Z_SPERR_make_cd_values(1, 6.4);
+    unsigned int cd_values = H5Z_SPERR_make_cd_values(1, 6.4, 0);
     if ((retval = nc_def_var_filter(ncid, varid, 32028, 1, &cd_values)))
       ERR(retval);
 

--- a/include/h5z-sperr.h
+++ b/include/h5z-sperr.h
@@ -11,14 +11,15 @@
 #define INTEGER_BITS 12
 
 /*
- * This function encodes both the SPERR compression mode and compression quality into
- * a 32-bit unsigned int. Valid input and its meaning:
+ * This function encodes 1) the SPERR compression mode, 2) compression quality, 3) if to swap
+ * rank orders into a 32-bit unsigned int. Valid input and its meaning:
  *   - Fixed bitrate compression:                mode = 1; quality = target bitrate.
  *   - Fixed PSNR compression:                   mode = 2; quality = target PSNR.
  *   - Fixed PWE (point-wise error) compression: mode = 3; quality = PWE tolerance.
+ *   - In all modes, swap != 0 means that need to perform rank order swaps.
  * The encoded value is returned and needs to be passed to HDF5 as `cd_values[1]`.
  */
-unsigned int H5Z_SPERR_make_cd_values(int mode, double quality)
+unsigned int H5Z_SPERR_make_cd_values(int mode, double quality, int swap)
 {
   assert(1 <= mode && mode <= 3);
   assert(quality > 0.0);
@@ -49,7 +50,7 @@ unsigned int H5Z_SPERR_make_cd_values(int mode, double quality)
       ret |= 1u << (INTEGER_BITS + FRACTIONAL_BITS - 1);
   }
 
-  /* encode mode in the top 4 bits */
+  /* Encode mode in bit 28, 29, and 30. */
   unsigned int mask = 0;
   switch (mode) {
     case 1:
@@ -66,14 +67,22 @@ unsigned int H5Z_SPERR_make_cd_values(int mode, double quality)
   }
   ret |= mask;
 
+  /* Encode swap flag at bit 31. */
+  if (swap)
+    ret |= 1u << (INTEGER_BITS + FRACTIONAL_BITS + 3);
+
   return ret;
 }
 
 void H5Z_SPERR_decode_cd_values(unsigned int cd_val, /* input */
                                 int* mode,           /* output */
-                                double* quality)     /* output */
+                                double* quality,     /* output */
+                                int* swap)           /* output */
 {
-  /* decode the compression mode from the top 4 bits */
+  /* Decode the rank swap flag. */
+  *swap = cd_val >> (INTEGER_BITS + FRACTIONAL_BITS + 3);
+
+  /* Decode the compression mode from the next 3 bits */
   unsigned int bit1 = (cd_val >> (INTEGER_BITS + FRACTIONAL_BITS)) & 1u;
   unsigned int bit2 = (cd_val >> (INTEGER_BITS + FRACTIONAL_BITS + 1)) & 1u;
   if (bit1 && !bit2)
@@ -87,7 +96,7 @@ void H5Z_SPERR_decode_cd_values(unsigned int cd_val, /* input */
   if ((cd_val >> (INTEGER_BITS + FRACTIONAL_BITS - 1)) & 1u)
     negative = 1;
 
-  /* zero out the top 4 bits and the sign bit (5 bits in total) */
+  /* Zero out the top 4 bits and the sign bit (5 bits in total) */
   unsigned int mask = 1u << (INTEGER_BITS + FRACTIONAL_BITS - 1);
   cd_val &= (mask - 1);
 

--- a/include/h5z-sperr.h
+++ b/include/h5z-sperr.h
@@ -16,7 +16,7 @@
  *   - Fixed bitrate compression:                mode = 1; quality = target bitrate.
  *   - Fixed PSNR compression:                   mode = 2; quality = target PSNR.
  *   - Fixed PWE (point-wise error) compression: mode = 3; quality = PWE tolerance.
- *   - In all modes, swap != 0 means that need to perform rank order swaps.
+ *   - In all modes, swap != 0 means to perform rank order swaps.
  * The encoded value is returned and needs to be passed to HDF5 as `cd_values[1]`.
  */
 unsigned int H5Z_SPERR_make_cd_values(int mode, double quality, int swap)

--- a/src/h5z-sperr.c
+++ b/src/h5z-sperr.c
@@ -1,12 +1,15 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <SPERR_C_API.h>
-
 #include <H5PLextern.h>
 #include <hdf5.h>
 
+#include <SPERR_C_API.h>
 #include "h5z-sperr.h"
+
+#ifndef NDEBUG
+#include <stdio.h>
+#endif
 
 static htri_t H5Z_can_apply_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
 {
@@ -23,32 +26,56 @@ static htri_t H5Z_can_apply_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     return 0;
   }
 
-  /* Get the dataspace rank. Fail if not 2 or 3. */
+  /* Get the dataspace rank. Fail if not 2, 3, or 4. */
   int ndims = H5Sget_simple_extent_ndims(space_id);
-  if (ndims < 2 || ndims > 3) {
+  if (ndims < 2 || ndims > 4) {
+#ifndef NDEBUG
+    printf("%s: %d, ndims = %d\n", __FILE__, __LINE__, ndims);
+#endif
     H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADTYPE,
-            "bad dataspace ranks. Only rank==2 or rank==3 are supported in H5Z-SPERR");
+            "bad dataspace ranks. Only rank==2, rank==3, or rank==4 with the time dimension==1 are "
+            "supported in H5Z-SPERR");
     return 0;
   }
 
-  /* Chunks have to be 2D or 3D as well, and to be conservative, we also check chunk sizes. */
-  hsize_t chunks[3];
-  ndims = H5Pget_chunk(dcpl_id, 3, chunks);
-  if (ndims < 2 || ndims > 3) {
+  /* Chunks have to be 2D, 3D, or 4D as well. */
+  hsize_t chunks[4] = {0, 0, 0, 0};
+  ndims = H5Pget_chunk(dcpl_id, 4, chunks);
+  if (ndims < 2 || ndims > 4) {
+#ifndef NDEBUG
+    printf("%s: %d, ndims = %d\n", __FILE__, __LINE__, ndims);
+#endif
     H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADTYPE,
-            "bad chunk ranks. Only rank==2 or rank==3 are supported in H5Z-SPERR");
+            "bad chunk ranks. Only rank==2, rank==3, or rank==4 with the time dimension==1 are "
+            "supported in H5Z-SPERR");
     return 0;
   }
 
-  bool bad_chunk = false;
+  /* Find out the real dimension. */
+  int real_dims = 0;
+  for (int i = 0; i < 4; i++)
+    if (chunks[i] > 1)
+      real_dims++;
+  if (real_dims < 2 || real_dims > 3) {
+#ifndef NDEBUG
+    printf("%s: %d, real_dims = %d\n", __FILE__, __LINE__, real_dims);
+#endif
+    H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADTYPE,
+            "bad chunk dimensions: only true 2D slices or 3D volumes are supported in H5Z-SPERR");
+    return 0;
+  }
+
+  /* Real chunk dimensions must be at least 9 */
   for (int i = 0; i < ndims; i++) {
-    if (chunks[i] < 9)
-      bad_chunk = true;
-  }
-  if (bad_chunk) {
-    H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADTYPE,
-            "bad chunk dimensions. (may relax this requirement in the future)");
-    return 0;
+    if (chunks[i] > 1 && chunks[i] < 9) {
+#ifndef NDEBUG
+      printf("%s: %d, chunks[%d] = %llu\n", __FILE__, __LINE__, i, chunks[i]);
+#endif
+      H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADTYPE,
+              "bad chunk dimensions: any dimension must be at least 9. (may relax this requirement "
+              "in the future)");
+      return 0;
+    }
   }
 
   return 1;
@@ -65,32 +92,22 @@ static unsigned int H5Z_SPERR_pack_data_type(int rank,  /* Input */
 
   /*
    * Bit position 0-3 to encode the rank.
-   * Only support 2, 3 right now.
+   * Since this function is called from `set_local()`, it should always be 2 or 3.
    */
   if (rank == 2) {
     ret |= 1u << 1; /* Position 1 */
   }
-  else if (rank == 3) {
+  else {
     ret |= 1u;      /* Position 0 */
     ret |= 1u << 1; /* Position 1 */
-  }
-  else {
-    H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADVALUE,
-            "Only 2D or 3D spaces are supported.");
-    return 0;
   }
 
   /*
    * Bit position 4-7 encode data type.
    * Only float (1) and double (0) are supported right now.
    */
-  if (dtype == 1)       /* is_float   */
-    ret |= 1u << 4;     /* Position 4 */
-  else if (dtype > 1) { /* error */
-    H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADTYPE,
-            "Only 32-bit or 64-bit floating point values are supported.");
-    return 0;
-  }
+  if (dtype == 1)   /* is_float   */
+    ret |= 1u << 4; /* Position 4 */
 
   return ret;
 }
@@ -135,54 +152,55 @@ static herr_t H5Z_set_local_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
    * 	space_id	Dataspace identifier
    */
 
-  /* Get the dataspace rank. It must be 2 or 3, since it passed the `can_apply` function. */
-  int rank = H5Sget_simple_extent_ndims(space_id);
-
-  /* Get the datatype size. It must be 4 or 8, since the float type is verified by `can_apply`. */
-  int is_float = 1;
-  if (H5Tget_size(type_id) == 8)
-    is_float = 0; /* !is_float i.e. double */
-
-  /* Get chunk sizes. */
-  hsize_t chunks[3];
-  int ndims = H5Pget_chunk(dcpl_id, 3, chunks);
-  if (ndims != rank) {
-    H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADSIZE,
-            "Somehow the chunk rank is different from two queries ??");
-    return -1;
-  }
-
   /* Get the user-specified compression mode and quality. */
-  size_t user_cd_nelem = 16, nchar = 16;
+  size_t user_cd_nelem = 2, nchar = 16;
   unsigned int user_cd_values[user_cd_nelem], flags;
   char name[nchar];
   herr_t status =
       H5Pget_filter_by_id(dcpl_id, H5Z_FILTER_SPERR, &flags, &user_cd_nelem, user_cd_values, nchar,
                           name, user_cd_values + user_cd_nelem - 1);
   if (user_cd_nelem != 1) {
+#ifndef NDEBUG
+    printf("%s: %d, user_cd_nelem = %lu\n", __FILE__, __LINE__, user_cd_nelem);
+#endif
     H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADSIZE,
-            "User cd_values[] isn't 3 elements ??");
+            "User cd_values[] isn't a single element ??");
     return -1;
   }
 
+  /* Get the datatype size. It must be 4 or 8, since the float type is verified by `can_apply`. */
+  int is_float = 1;
+  if (H5Tget_size(type_id) == 8)
+    is_float = 0; /* !is_float, i.e. double */
+
+  /* Get chunk sizes. */
+  hsize_t chunks[4] = {0, 0, 0, 0};
+  int ndims = H5Pget_chunk(dcpl_id, 4, chunks);
+  int real_dims = 0;
+  for (int i = 0; i < 4; i++)
+    if (chunks[i] > 1)
+      real_dims++;
+
   /*
-   * Assemble the meta info (cd_values[4] or cd_values[5]) to be stored.
-   * [0]  : 2D/3D, float/double, compression mode.
+   * Assemble the meta info to be stored.
+   * [0]  : 2D/3D, float/double
    * [1]  : compression specifics
    * [2-3]: (dimx, dimy) in 2D cases.
    * [2-4]: (dimx, dimy, dimz) in 3D cases.
    */
   unsigned int cd_values[5] = {0, 0, 0, 0, 0};
-  cd_values[0] = H5Z_SPERR_pack_data_type(rank, is_float);
+  cd_values[0] = H5Z_SPERR_pack_data_type(real_dims, is_float);
   cd_values[1] = user_cd_values[0];
-  cd_values[2] = chunks[0];
-  cd_values[3] = chunks[1];
-  if (rank == 2)
-    H5Pmodify_filter(dcpl_id, H5Z_FILTER_SPERR, H5Z_FLAG_MANDATORY, 4, cd_values);
-  else {
-    cd_values[4] = chunks[2];
-    H5Pmodify_filter(dcpl_id, H5Z_FILTER_SPERR, H5Z_FLAG_MANDATORY, 5, cd_values);
+  int i1 = 2, i2 = 0;
+  while (i2 < 4) {
+    if (chunks[i2] > 1)
+      cd_values[i1++] = chunks[i2];
+    i2++;
   }
+  if (real_dims == 2)
+    H5Pmodify_filter(dcpl_id, H5Z_FILTER_SPERR, H5Z_FLAG_MANDATORY, 4, cd_values);
+  else
+    H5Pmodify_filter(dcpl_id, H5Z_FILTER_SPERR, H5Z_FLAG_MANDATORY, 5, cd_values);
 
   return 0;
 }
@@ -195,20 +213,33 @@ static size_t H5Z_filter_sperr(unsigned int flags,
                                void** buf)
 {
   /* Extract info from cd_values[] */
-  int rank, is_float;
+  int rank = 0, is_float = 0;
   H5Z_SPERR_unpack_data_type(cd_values[0], &rank, &is_float);
   if ((rank == 2 && cd_nelmts != 4) || (rank == 3 && cd_nelmts != 5)) {
+#ifndef NDEBUG
+    printf("rank = %d, cd_nelmts = %lu\n", rank, cd_nelmts);
+#endif
     H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, H5E_ERR_CLS, H5E_PLINE, H5E_BADVALUE,
             "SPERR filter cd_values[] length not correct.");
     return 0;
   }
 
-  int mode;
-  double quality;
-  H5Z_SPERR_decode_cd_values(cd_values[1], &mode, &quality);
-  unsigned int dims[3] = {cd_values[2], cd_values[3], 1};
-  if (rank == 3)
-    dims[2] = cd_values[4];
+  int mode = 0, swap = 0;
+  double quality = 0.0;
+  H5Z_SPERR_decode_cd_values(cd_values[1], &mode, &quality, &swap);
+  unsigned int dims[3] = {cd_values[2], cd_values[3], rank == 2 ? 1 : cd_values[4]};
+  if (swap) {
+    if (rank == 2) {
+      unsigned int tmp = dims[0];
+      dims[0] = dims[1];
+      dims[1] = tmp;
+    }
+    else {
+      unsigned int tmp = dims[0];
+      dims[0] = dims[2];
+      dims[2] = tmp;
+    }
+  }
 
   /* Decompression */
   if (flags & H5Z_FLAG_REVERSE) {
@@ -217,7 +248,7 @@ static size_t H5Z_filter_sperr(unsigned int flags,
     if (rank == 2)
       ret = sperr_decomp_2d(*buf, nbytes, is_float, dims[0], dims[1], &dst);
     else {
-      size_t dimx, dimy, dimz;
+      size_t dimx = 0, dimy = 0, dimz = 0;
       ret = sperr_decomp_3d(*buf, nbytes, is_float, 1, &dimx, &dimy, &dimz, &dst);
     }
     if (ret != 0) {

--- a/src/h5z-sperr.c
+++ b/src/h5z-sperr.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -98,6 +99,7 @@ static unsigned int H5Z_SPERR_pack_data_type(int rank,  /* Input */
     ret |= 1u << 1; /* Position 1 */
   }
   else {
+    assert(rank == 3);
     ret |= 1u;      /* Position 0 */
     ret |= 1u << 1; /* Position 1 */
   }
@@ -108,6 +110,8 @@ static unsigned int H5Z_SPERR_pack_data_type(int rank,  /* Input */
    */
   if (dtype == 1)   /* is_float   */
     ret |= 1u << 4; /* Position 4 */
+  else
+    assert(dtype == 0);
 
   return ret;
 }
@@ -172,6 +176,8 @@ static herr_t H5Z_set_local_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
   int is_float = 1;
   if (H5Tget_size(type_id) == 8)
     is_float = 0; /* !is_float, i.e. double */
+  else
+    assert(H5Tget_size(type_id) == 4);
 
   /* Get chunk sizes. */
   hsize_t chunks[4] = {0, 0, 0, 0};
@@ -180,6 +186,7 @@ static herr_t H5Z_set_local_sperr(hid_t dcpl_id, hid_t type_id, hid_t space_id)
   for (int i = 0; i < 4; i++)
     if (chunks[i] > 1)
       real_dims++;
+  assert(real_dims == 2 || real_dims == 3);
 
   /*
    * Assemble the meta info to be stored.

--- a/utilities/example-2d.c
+++ b/utilities/example-2d.c
@@ -66,7 +66,7 @@ int main (int argc, char* argv[])
      */
     int mode = atoi(argv[4]);
     double quality = atof(argv[5]);
-    unsigned int cd_values = H5Z_SPERR_make_cd_values(mode, quality);
+    unsigned int cd_values = H5Z_SPERR_make_cd_values(mode, quality, 0);
     status = H5Pset_filter(prop, H5Z_FILTER_SPERR, H5Z_FLAG_MANDATORY, 1, &cd_values);
 
     /*

--- a/utilities/example-3d.c
+++ b/utilities/example-3d.c
@@ -66,7 +66,7 @@ int main (int argc, char* argv[])
      */
     int mode = atoi(argv[5]);
     double quality = atof(argv[6]);
-    unsigned int cd_values = H5Z_SPERR_make_cd_values(mode, quality);
+    unsigned int cd_values = H5Z_SPERR_make_cd_values(mode, quality, 0);
     status = H5Pset_filter(prop, H5Z_FILTER_SPERR, H5Z_FLAG_MANDATORY, 1, &cd_values);
 
     /*

--- a/utilities/generate_cd_values.c
+++ b/utilities/generate_cd_values.c
@@ -5,7 +5,7 @@
 int main(int argc, char* argv[])
 {
   if (argc < 3 || argc > 4) {
-    printf("Usage: ./generate_cd_values  compression_mode  compression_quality  [rank_swap]\n");
+    printf("Usage: ./generate_cd_values  compression_mode  compression_quality  [rank_swap_flag]\n");
     exit(1);
   }
 

--- a/utilities/generate_cd_values.c
+++ b/utilities/generate_cd_values.c
@@ -4,19 +4,22 @@
 
 int main(int argc, char* argv[])
 {
-  if (argc != 3) {
-    printf("Usage: ./generate_cd_values  compression_mode  compression_quality\n");
+  if (argc < 3 || argc > 4) {
+    printf("Usage: ./generate_cd_values  compression_mode  compression_quality  [rank_swap]\n");
     exit(1);
   }
 
   int mode = atoi(argv[1]);
   double quality = atof(argv[2]);
-  unsigned int cd_values = H5Z_SPERR_make_cd_values(mode, quality);
+  int swap = argc == 3 ? 0 : 1;
+  unsigned int cd_values = H5Z_SPERR_make_cd_values(mode, quality, swap);
+
+  H5Z_SPERR_decode_cd_values(cd_values, &mode, &quality, &swap);
 
   switch (mode) {
     case 1:
       if (quality > 0.0 && quality < 64.0)
-        printf("For fixed-rate compression with a bitrate of %.f,\n", quality);
+        printf("For fixed-rate compression with a bitrate of %.4f,", quality);
       else {
         printf("Target bitrate should in between of 0.0 and 64.0\n");
         exit(1);
@@ -24,7 +27,7 @@ int main(int argc, char* argv[])
       break;
     case 2:
       if (quality > 0.0) 
-        printf("For fixed-PSNR compression with a target PSNR of %.f,\n", quality);
+        printf("For fixed-PSNR compression with a target PSNR of %.4f,", quality);
       else {
         printf("Target PSNR should be greater than 0.0.\n");
         exit(1);
@@ -32,7 +35,7 @@ int main(int argc, char* argv[])
       break;
     case 3:
       if (quality > 0.0) 
-        printf("For fixed-PWE compression with a PWE tolerance of %.f,\n", quality);
+        printf("For fixed-PWE compression with a PWE tolerance of %.4g,", quality);
       else {
         printf("PWE tolerance should be greater than 0.0.\n");
         exit(1);
@@ -42,7 +45,11 @@ int main(int argc, char* argv[])
       printf("Compression mode should be 1, 2, or 3\n");
         exit(1);
   }
-  
+
+  if (swap)
+    printf(" swapping rank orders,\n");
+  else
+    printf(" without swapping rank orders,\n");
   printf("H5Z-SPERR cd_values = %uu (Filter ID = %d).\n", cd_values, H5Z_FILTER_SPERR);
   printf("Please use this value as a single 32-bit unsigned integer in your applications.\n");
 }


### PR DESCRIPTION
This PR implements logic that detects fake ranks, i.e., ranks with `dimension=1`.

As a result, a chunk with dimensions of `(1, 5, 5, 5)` will be identified as a 3D volume of `(5, 5, 5)`, and a chunk of `(1, 1, 5, 5)` will be identified as a 2D slice, and so on.

This PR also implements a rank order swap mechanism, so that a chunk of `(128, 256, 512)` can optionally be identified as `(512, 256, 128)` when passing into the compressor. 